### PR TITLE
Feature/신입회원 모집 페이지 관리자 #38

### DIFF
--- a/src/page/Recruit/Recruit.jsx
+++ b/src/page/Recruit/Recruit.jsx
@@ -5,16 +5,16 @@ import RecruitForm from './RecruitForm';
 
 const Recruit = () => {
   return (
-    <div className="h-content w-screen flex justify-center align-center bg-grayLight">
-      <div className="h-full w-4/5 flex justify-center align-center">
-        <div className="h-full w-full grid grid-cols-2 gap-4 grid-rows-1">
-          <div className="h-full w-full flex">
-            <div className="h-5/6 w-full self-center">
+    <div className="flex justify-center w-screen overflow-x-hidden h-content align-center bg-grayLight">
+      <div className="flex flex-col justify-center w-4/5 h-fit align-center">
+        <div className="grid w-full h-full grid-cols-2 grid-rows-1 gap-4">
+          <div className="flex items-start w-full h-full mt-16">
+            <div className="sticky w-full top-16 h-fit">
               <RecruitDescription />
             </div>
           </div>
-          <div className="h-full w-full flex">
-            <div className="h-5/6 w-full self-center">
+          <div className="flex items-start w-full h-full mt-16">
+            <div className="w-full h-5/6">
               <RecruitForm />
             </div>
           </div>

--- a/src/page/Recruit/RecruitDescription.jsx
+++ b/src/page/Recruit/RecruitDescription.jsx
@@ -4,7 +4,7 @@ import RecruitImg from 'asset/recruit/recruitImg.png';
 
 const RecruitDescription = () => {
   return (
-    <div className="sticky top-0 flex flex-col items-center justify-start w-full h-full px-12 text-sm font-normal">
+    <div className="top-0 flex flex-col items-center justify-start w-full h-full px-12 text-sm font-normal">
       <div className="mb-10 h-2/5">
         <h1 className="mb-16 text-4xl">UntoC 16기 신입회원 모집</h1>
         <h2 className="mb-10 text-base text-yellowPoint">모집기간 : 2023.08.15 ~ 2023.08.31</h2>

--- a/src/page/Recruit/RecruitDescription.jsx
+++ b/src/page/Recruit/RecruitDescription.jsx
@@ -4,10 +4,10 @@ import RecruitImg from 'asset/recruit/recruitImg.png';
 
 const RecruitDescription = () => {
   return (
-    <div className="h-full w-full px-12 flex flex-col justify-start items-center font-normal text-sm">
-      <div className="h-2/5 mb-10">
-        <h1 className="text-4xl mb-16">UntoC 16기 신입회원 모집</h1>
-        <h2 className="text-base text-yellowPoint mb-10">모집기간 : 2023.08.15 ~ 2023.08.31</h2>
+    <div className="sticky top-0 flex flex-col items-center justify-start w-full h-full px-12 text-sm font-normal">
+      <div className="mb-10 h-2/5">
+        <h1 className="mb-16 text-4xl">UntoC 16기 신입회원 모집</h1>
+        <h2 className="mb-10 text-base text-yellowPoint">모집기간 : 2023.08.15 ~ 2023.08.31</h2>
         <p>
           지원을 하실 때, 학번 이름, 전화번호를 정확하게 기재해주세요. <br />
           지원 기한 종료 이후에는 해당 데이터를 안전하게 폐기할 예정이오니 <br />

--- a/src/page/Recruit/RecruitDescription.jsx
+++ b/src/page/Recruit/RecruitDescription.jsx
@@ -4,7 +4,7 @@ import RecruitImg from 'asset/recruit/recruitImg.png';
 
 const RecruitDescription = () => {
   return (
-    <div className="top-0 flex flex-col items-center justify-start w-full h-full px-12 text-sm font-normal">
+    <div className="flex flex-col items-center justify-start w-full h-full px-12 text-sm font-normal">
       <div className="mb-10 h-2/5">
         <h1 className="mb-16 text-4xl">UntoC 16기 신입회원 모집</h1>
         <h2 className="mb-10 text-base text-yellowPoint">모집기간 : 2023.08.15 ~ 2023.08.31</h2>

--- a/src/page/Recruit/RecruitForm.jsx
+++ b/src/page/Recruit/RecruitForm.jsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 
-import { useSelector } from 'react-redux';
+import useRoleCheck from 'hooks/useRoleCheck';
 
 import RecruitFormAdmin from './RecruitFormAdmin';
 import RecruitFormUser from './RecruitFormUser';
 
 const RecruitForm = () => {
-  const { type: role } = useSelector((state) => state.user);
+  const { isLogin } = useRoleCheck('admin');
   const [applyQuestions, setApplyQuestions] = useState([]);
   const [originalApplyQuestions, setOriginalApplyQuestions] = useState([]);
   const [isChanged, setIsChanged] = useState(false);
@@ -56,7 +56,7 @@ const RecruitForm = () => {
                 id="studentId"
                 placeholder="20230001"
                 className="w-full p-1 border-2 border-borderColor focus:outline-none focus:border-grayDark"
-                disabled={role === 'admin'}
+                disabled={isLogin}
               />
             </label>
             <label htmlFor="name" className="w-60">
@@ -67,7 +67,7 @@ const RecruitForm = () => {
                 id="name"
                 placeholder="홍길동"
                 className="w-full p-1 border-2 border-borderColor focus:outline-none focus:border-grayDark"
-                disabled={role === 'admin'}
+                disabled={isLogin}
               />
             </label>
           </div>
@@ -80,11 +80,11 @@ const RecruitForm = () => {
                 id="phone"
                 placeholder="010-1234-5678"
                 className="w-full p-1 border-2 border-borderColor focus:outline-none focus:border-grayDark"
-                disabled={role === 'admin'}
+                disabled={isLogin}
               />
             </label>
           </div>
-          {role === 'admin' ? (
+          {isLogin ? (
             <RecruitFormAdmin
               applyQuestions={applyQuestions}
               setApplyQuestions={setApplyQuestions}
@@ -105,7 +105,7 @@ const RecruitForm = () => {
           />
           <input
             onClick={
-              role === 'admin'
+              isLogin
                 ? () => {
                     setOriginalApplyQuestions([...applyQuestions]);
                   }
@@ -114,9 +114,9 @@ const RecruitForm = () => {
                   }
             }
             type="button"
-            value={role === 'admin' ? '저장' : '제출'}
+            value={isLogin ? '저장' : '제출'}
             className="w-1/4 ml-3 text-white border rounded h-7 border-yellowPoint bg-yellowPoint hover:cursor-pointer disabled:bg-grayPoint disabled:border-grayPoint disabled:text-grayDark"
-            disabled={!isChanged && role === 'admin'}
+            disabled={!isChanged && isLogin}
           />
         </div>
       </div>

--- a/src/page/Recruit/RecruitForm.jsx
+++ b/src/page/Recruit/RecruitForm.jsx
@@ -9,6 +9,7 @@ const RecruitForm = () => {
   const { type: role } = useSelector((state) => state.user);
   const [applyQuestions, setApplyQuestions] = useState([]);
   const [originalApplyQuestions, setOriginalApplyQuestions] = useState([]);
+  const [isChanged, setIsChanged] = useState(false);
 
   useEffect(() => {
     setOriginalApplyQuestions(() => [
@@ -46,9 +47,9 @@ const RecruitForm = () => {
       </div>
       <div className="relative flex flex-col items-center justify-between w-full h-full">
         <div className="w-full h-5/6">
-          <div className="flex items-center justify-between w-full h-24 mb-3">
+          <div className="grid w-full h-24 grid-cols-2 mb-3">
             <label htmlFor="studentId" className="w-60">
-              <p className="mb-3">학번</p>
+              <p className="mb-3 text-grayDark">학번</p>
               <input
                 type="text"
                 name="studentId"
@@ -59,7 +60,7 @@ const RecruitForm = () => {
               />
             </label>
             <label htmlFor="name" className="w-60">
-              <p className="mb-3">이름</p>
+              <p className="mb-3 text-grayDark">이름</p>
               <input
                 type="text"
                 name="name"
@@ -72,7 +73,7 @@ const RecruitForm = () => {
           </div>
           <div className="w-full h-24 mb-3">
             <label htmlFor="phone">
-              <p className="mb-3">전화번호</p>
+              <p className="mb-3 text-grayDark">전화번호</p>
               <input
                 type="text"
                 name="phone-number"
@@ -84,7 +85,11 @@ const RecruitForm = () => {
             </label>
           </div>
           {role === 'admin' ? (
-            <RecruitFormAdmin applyQuestions={applyQuestions} setApplyQuestions={setApplyQuestions} />
+            <RecruitFormAdmin
+              applyQuestions={applyQuestions}
+              setApplyQuestions={setApplyQuestions}
+              setIsChanged={setIsChanged}
+            />
           ) : (
             <RecruitFormUser applyQuestions={applyQuestions} />
           )}
@@ -93,7 +98,7 @@ const RecruitForm = () => {
           <input
             type="button"
             value="취소"
-            className="w-1/4 border rounded h-7 border-borderColor hover:cursor-pointer"
+            className="w-1/4 border rounded h-7 border-borderColor hover:cursor-pointer text-grayDark"
             onClick={() => {
               setApplyQuestions([...originalApplyQuestions]);
             }}
@@ -110,7 +115,8 @@ const RecruitForm = () => {
             }
             type="button"
             value={role === 'admin' ? '저장' : '제출'}
-            className="w-1/4 ml-3 text-white border rounded h-7 border-yellowPoint bg-yellowPoint hover:cursor-pointer"
+            className="w-1/4 ml-3 text-white border rounded h-7 border-yellowPoint bg-yellowPoint hover:cursor-pointer disabled:bg-grayPoint disabled:border-grayPoint disabled:text-grayDark"
+            disabled={!isChanged && role === 'admin'}
           />
         </div>
       </div>

--- a/src/page/Recruit/RecruitForm.jsx
+++ b/src/page/Recruit/RecruitForm.jsx
@@ -1,14 +1,52 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+import { useSelector } from 'react-redux';
+
+import RecruitFormAdmin from './RecruitFormAdmin';
+import RecruitFormUser from './RecruitFormUser';
 
 const RecruitForm = () => {
+  const { type: role } = useSelector((state) => state.user);
+  const [applyQuestions, setApplyQuestions] = useState([]);
+  const [originalApplyQuestions, setOriginalApplyQuestions] = useState([]);
+
+  useEffect(() => {
+    setOriginalApplyQuestions(() => [
+      {
+        id: '1',
+        question: '동아리 지원 동기 (300자 이내)',
+        content: 'UntoC 동아리를 지원하게 된 이유에 대해 설명해주세요.최소 30자 이상의 내용이 필요합니다.',
+      },
+      {
+        id: '2',
+        question: '동아리에서 하고 싶은 활동 (300자 이내)',
+        content:
+          'UntoC 동아리에 들어오게 된다면 하고싶은 활동에 대해 적어주세요.위 내용을 바탕으로 동아리에 기여할 수 있는 아이디어를 제공하고,스터디 및 팀을 구성할 때 참고자료가 될 수 있습니다.',
+      },
+    ]);
+    setApplyQuestions(() => [
+      {
+        id: '1',
+        question: '동아리 지원 동기 (300자 이내)',
+        content: 'UntoC 동아리를 지원하게 된 이유에 대해 설명해주세요.최소 30자 이상의 내용이 필요합니다.',
+      },
+      {
+        id: '2',
+        question: '동아리에서 하고 싶은 활동 (300자 이내)',
+        content:
+          'UntoC 동아리에 들어오게 된다면 하고싶은 활동에 대해 적어주세요.위 내용을 바탕으로 동아리에 기여할 수 있는 아이디어를 제공하고,스터디 및 팀을 구성할 때 참고자료가 될 수 있습니다.',
+      },
+    ]);
+  }, []);
+
   return (
-    <form className="h-full w-full bg-white shadow-lg rounded-3xl p-12 relative font-normal text-sm">
-      <div className="h-16 w-52 bg-white absolute -top-11 left-0 flex justify-center items-center rounded-t-xl text-lg text-yellowPoint">
+    <form className="relative w-full p-12 text-sm font-normal bg-white shadow-lg h-fit rounded-3xl">
+      <div className="absolute left-0 flex items-center justify-center h-16 text-lg bg-white w-52 -top-11 rounded-t-xl text-yellowPoint">
         Fill out this form
       </div>
-      <div className="h-full w-full flex flex-col justify-between items-center">
-        <div className="h-5/6 w-full">
-          <div className="h-1/5 w-full flex justify-between items-center mb-3">
+      <div className="relative flex flex-col items-center justify-between w-full h-full">
+        <div className="w-full h-5/6">
+          <div className="flex items-center justify-between w-full h-24 mb-3">
             <label htmlFor="studentId" className="w-60">
               <p className="mb-3">학번</p>
               <input
@@ -16,7 +54,8 @@ const RecruitForm = () => {
                 name="studentId"
                 id="studentId"
                 placeholder="20230001"
-                className="w-full border border-grayPoint p-1"
+                className="w-full p-1 border-2 border-borderColor focus:outline-none focus:border-grayDark"
+                disabled={role === 'admin'}
               />
             </label>
             <label htmlFor="name" className="w-60">
@@ -26,11 +65,12 @@ const RecruitForm = () => {
                 name="name"
                 id="name"
                 placeholder="홍길동"
-                className="w-full border border-grayPoint p-1"
+                className="w-full p-1 border-2 border-borderColor focus:outline-none focus:border-grayDark"
+                disabled={role === 'admin'}
               />
             </label>
           </div>
-          <div className="h-1/5 w-full mb-3">
+          <div className="w-full h-24 mb-3">
             <label htmlFor="phone">
               <p className="mb-3">전화번호</p>
               <input
@@ -38,44 +78,39 @@ const RecruitForm = () => {
                 name="phone-number"
                 id="phone"
                 placeholder="010-1234-5678"
-                className="w-full border border-grayPoint p-1"
+                className="w-full p-1 border-2 border-borderColor focus:outline-none focus:border-grayDark"
+                disabled={role === 'admin'}
               />
             </label>
           </div>
-          <div className="h-1/4 w-full mb-3">
-            <label htmlFor="reason">
-              <p className="mb-3">동아리 지원 동기 (300자 이내)</p>
-              <textarea
-                type="text"
-                name="reason"
-                id="reason"
-                placeholder="UntoC 동아리를 지원하게 된 이유에 대해 설명해주세요.
-                최소 30자 이상의 내용이 필요합니다."
-                className="h-2/3 w-full border border-grayPoint p-1 resize-none"
-              />
-            </label>
-          </div>
-          <div className="h-1/4 w-full mb-3">
-            <label htmlFor="activity">
-              <p className="mb-3">동아리에서 하고 싶은 활동 (300자 이내)</p>
-              <textarea
-                type="text"
-                name="activity"
-                id="activity"
-                placeholder="UntoC 동아리에 들어오게 된다면 하고싶은 활동에 대해 적어주세요.
-                위 내용을 바탕으로 동아리에 기여할 수 있는 아이디어를 제공하고,
-                스터디 및 팀을 구성할 때 참고자료가 될 수 있습니다."
-                className="h-2/3 w-full border border-grayPoint p-1 resize-none"
-              />
-            </label>
-          </div>
+          {role === 'admin' ? (
+            <RecruitFormAdmin applyQuestions={applyQuestions} setApplyQuestions={setApplyQuestions} />
+          ) : (
+            <RecruitFormUser applyQuestions={applyQuestions} />
+          )}
         </div>
-        <div className="h-1/6 w-full flex justify-end items-center">
-          <input type="button" value="취소" className="h-7 w-1/4 border border-borderColor rounded" />
+        <div className="flex items-center justify-end w-full h-1/6">
           <input
             type="button"
-            value="제출"
-            className="h-7 w-1/4 ml-3 border border-yellowPoint bg-yellowPoint text-white rounded"
+            value="취소"
+            className="w-1/4 border rounded h-7 border-borderColor hover:cursor-pointer"
+            onClick={() => {
+              setApplyQuestions([...originalApplyQuestions]);
+            }}
+          />
+          <input
+            onClick={
+              role === 'admin'
+                ? () => {
+                    setOriginalApplyQuestions([...applyQuestions]);
+                  }
+                : () => {
+                    setApplyQuestions([...originalApplyQuestions]);
+                  }
+            }
+            type="button"
+            value={role === 'admin' ? '저장' : '제출'}
+            className="w-1/4 ml-3 text-white border rounded h-7 border-yellowPoint bg-yellowPoint hover:cursor-pointer"
           />
         </div>
       </div>

--- a/src/page/Recruit/RecruitForm.jsx
+++ b/src/page/Recruit/RecruitForm.jsx
@@ -8,23 +8,10 @@ import RecruitFormUser from './RecruitFormUser';
 const RecruitForm = () => {
   const { isLogin } = useRoleCheck('admin');
   const [applyQuestions, setApplyQuestions] = useState([]);
-  const [originalApplyQuestions, setOriginalApplyQuestions] = useState([]);
   const [isChanged, setIsChanged] = useState(false);
 
-  useEffect(() => {
-    setOriginalApplyQuestions(() => [
-      {
-        id: '1',
-        question: '동아리 지원 동기 (300자 이내)',
-        content: 'UntoC 동아리를 지원하게 된 이유에 대해 설명해주세요.최소 30자 이상의 내용이 필요합니다.',
-      },
-      {
-        id: '2',
-        question: '동아리에서 하고 싶은 활동 (300자 이내)',
-        content:
-          'UntoC 동아리에 들어오게 된다면 하고싶은 활동에 대해 적어주세요.위 내용을 바탕으로 동아리에 기여할 수 있는 아이디어를 제공하고,스터디 및 팀을 구성할 때 참고자료가 될 수 있습니다.',
-      },
-    ]);
+  const getApplyQuestions = () => {
+    // Todo: get applyQuestions from server
     setApplyQuestions(() => [
       {
         id: '1',
@@ -38,6 +25,10 @@ const RecruitForm = () => {
           'UntoC 동아리에 들어오게 된다면 하고싶은 활동에 대해 적어주세요.위 내용을 바탕으로 동아리에 기여할 수 있는 아이디어를 제공하고,스터디 및 팀을 구성할 때 참고자료가 될 수 있습니다.',
       },
     ]);
+  };
+
+  useEffect(() => {
+    getApplyQuestions();
   }, []);
 
   return (
@@ -98,9 +89,7 @@ const RecruitForm = () => {
           <button
             type="button"
             className="w-1/4 border rounded h-7 border-borderColor hover:cursor-pointer text-grayDark"
-            onClick={() => {
-              setApplyQuestions([...originalApplyQuestions]);
-            }}
+            onClick={getApplyQuestions}
           >
             취소
           </button>
@@ -108,10 +97,10 @@ const RecruitForm = () => {
             onClick={
               isLogin
                 ? () => {
-                    setOriginalApplyQuestions([...applyQuestions]);
+                    // @Todo: save applyQuestions for admin
                   }
                 : () => {
-                    setApplyQuestions([...originalApplyQuestions]);
+                    // @Todo: summit applyQuestions for guest
                   }
             }
             type="button"

--- a/src/page/Recruit/RecruitForm.jsx
+++ b/src/page/Recruit/RecruitForm.jsx
@@ -95,15 +95,16 @@ const RecruitForm = () => {
           )}
         </div>
         <div className="flex items-center justify-end w-full h-1/6">
-          <input
+          <button
             type="button"
-            value="취소"
             className="w-1/4 border rounded h-7 border-borderColor hover:cursor-pointer text-grayDark"
             onClick={() => {
               setApplyQuestions([...originalApplyQuestions]);
             }}
-          />
-          <input
+          >
+            취소
+          </button>
+          <button
             onClick={
               isLogin
                 ? () => {
@@ -114,10 +115,11 @@ const RecruitForm = () => {
                   }
             }
             type="button"
-            value={isLogin ? '저장' : '제출'}
             className="w-1/4 ml-3 text-white border rounded h-7 border-yellowPoint bg-yellowPoint hover:cursor-pointer disabled:bg-grayPoint disabled:border-grayPoint disabled:text-grayDark"
             disabled={!isChanged && isLogin}
-          />
+          >
+            {isLogin ? '저장' : '제출'}
+          </button>
         </div>
       </div>
     </form>

--- a/src/page/Recruit/RecruitForm.jsx
+++ b/src/page/Recruit/RecruitForm.jsx
@@ -39,25 +39,25 @@ const RecruitForm = () => {
       <div className="relative flex flex-col items-center justify-between w-full h-full">
         <div className="w-full h-5/6">
           <div className="grid w-full h-24 grid-cols-2 mb-3">
-            <label htmlFor="studentId" className="w-60">
+            <label htmlFor="studentId" className="w-11/12">
               <p className="mb-3 text-grayDark">학번</p>
               <input
                 type="text"
                 name="studentId"
                 id="studentId"
                 placeholder="20230001"
-                className="w-full p-1 border-2 border-borderColor focus:outline-none focus:border-grayDark"
+                className="w-full p-1 px-3 border border-borderColor focus:outline-none focus:border-grayDark"
                 disabled={isLogin}
               />
             </label>
-            <label htmlFor="name" className="w-60">
+            <label htmlFor="name" className="w-11/12 justify-self-end">
               <p className="mb-3 text-grayDark">이름</p>
               <input
                 type="text"
                 name="name"
                 id="name"
                 placeholder="홍길동"
-                className="w-full p-1 border-2 border-borderColor focus:outline-none focus:border-grayDark"
+                className="w-full p-1 px-3 border border-borderColor focus:outline-none focus:border-grayDark"
                 disabled={isLogin}
               />
             </label>
@@ -70,20 +70,25 @@ const RecruitForm = () => {
                 name="phone-number"
                 id="phone"
                 placeholder="010-1234-5678"
-                className="w-full p-1 border-2 border-borderColor focus:outline-none focus:border-grayDark"
+                className="w-full p-1 px-3 border border-borderColor focus:outline-none focus:border-grayDark"
                 disabled={isLogin}
               />
             </label>
           </div>
-          {isLogin ? (
-            <RecruitFormAdmin
-              applyQuestions={applyQuestions}
-              setApplyQuestions={setApplyQuestions}
-              setIsChanged={setIsChanged}
-            />
-          ) : (
-            <RecruitFormUser applyQuestions={applyQuestions} />
-          )}
+          {
+            /**
+             * @Todo if elseComponent is added to useRoleCheck, change this code
+             */
+            isLogin ? (
+              <RecruitFormAdmin
+                applyQuestions={applyQuestions}
+                setApplyQuestions={setApplyQuestions}
+                setIsChanged={setIsChanged}
+              />
+            ) : (
+              <RecruitFormUser applyQuestions={applyQuestions} />
+            )
+          }
         </div>
         <div className="flex items-center justify-end w-full h-1/6">
           <button
@@ -97,10 +102,10 @@ const RecruitForm = () => {
             onClick={
               isLogin
                 ? () => {
-                    // @Todo: save applyQuestions for admin
+                    /** @Todo save applyQuestions for admin */
                   }
                 : () => {
-                    // @Todo: summit applyQuestions for guest
+                    /** @Todo submit applyQuestions for guest */
                   }
             }
             type="button"

--- a/src/page/Recruit/RecruitFormAdmin.jsx
+++ b/src/page/Recruit/RecruitFormAdmin.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+import { CiSquarePlus } from 'react-icons/ci';
+
+const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions }) => {
+  const addQuestion = () => {
+    setApplyQuestions([
+      ...applyQuestions,
+      {
+        id: `${Math.random() * 100000}`,
+        question: '',
+        content: '',
+      },
+    ]);
+  };
+
+  const removeQuestion = (index) => {
+    setApplyQuestions(applyQuestions.filter((applyQuestion, idx) => idx !== index));
+  };
+
+  return (
+    <>
+      {applyQuestions.map((applyQuestion, idx) => {
+        const { id, question, content } = applyQuestion;
+        return (
+          <div className="w-full h-32 mb-8">
+            <label htmlFor={id}>
+              <div className="flex justify-between">
+                <input
+                  className="relative w-9/12 mb-3 border-b-2 border-borderColor focus:outline-none focus:border-b-grayDark"
+                  value={question}
+                  onChange={(e) => {
+                    setApplyQuestions([
+                      ...applyQuestions.slice(0, idx),
+                      { id, question: e.target.value, content },
+                      ...applyQuestions.slice(idx + 1),
+                    ]);
+                  }}
+                  placeholder="목록 제목을 입력해주세요"
+                />
+                <div className="flex justify-end w-1/6 h-full">
+                  <button
+                    className="w-full font-bold border-2 rounded border-error text-error"
+                    type="button"
+                    onClick={() => removeQuestion(idx)}
+                  >
+                    삭제
+                  </button>
+                </div>
+              </div>
+              <textarea
+                type="text"
+                name={id}
+                id={id}
+                value={content}
+                className="w-full p-1 border-2 resize-none h-2/3 border-borderColor focus:outline-none focus:border-grayDark"
+                onChange={(e) => {
+                  setApplyQuestions([
+                    ...applyQuestions.slice(0, idx),
+                    { id, content: e.target.value, question },
+                    ...applyQuestions.slice(idx + 1),
+                  ]);
+                }}
+                placeholder="목록에 대한 설명을 입력해주세요"
+              />
+            </label>
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        className="flex items-center justify-start w-1/3 text-placeHolder hover:underline"
+        onClick={addQuestion}
+      >
+        <CiSquarePlus size={32} className="mr-2 text-grayDark" />
+        <p className="h-full hover:underline">지원서 목록 추가</p>
+      </button>
+    </>
+  );
+};
+
+RecruitFormAdmin.propTypes = {
+  applyQuestions: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      question: PropTypes.string,
+      content: PropTypes.string,
+    }),
+  ).isRequired,
+  setApplyQuestions: PropTypes.func.isRequired,
+};
+
+export default RecruitFormAdmin;

--- a/src/page/Recruit/RecruitFormAdmin.jsx
+++ b/src/page/Recruit/RecruitFormAdmin.jsx
@@ -6,8 +6,8 @@ import { CiSquarePlus } from 'react-icons/ci';
 const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions, setIsChanged }) => {
   const addQuestion = () => {
     setIsChanged(true);
-    setApplyQuestions([
-      ...applyQuestions,
+    setApplyQuestions((prev) => [
+      ...prev,
       {
         id: `${Math.random() * 100000}`,
         question: '',
@@ -18,15 +18,16 @@ const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions, setIsChanged }) =
 
   const removeQuestion = (index) => {
     setIsChanged(true);
-    setApplyQuestions(applyQuestions.filter((applyQuestion, idx) => idx !== index));
+    setApplyQuestions((prev) => {
+      prev.filter((applyQuestion, idx) => idx !== index);
+    });
   };
 
   return (
     <>
-      {applyQuestions.map((applyQuestion, idx) => {
-        const { id, question, content } = applyQuestion;
+      {applyQuestions.map(({ id, question, content }, idx) => {
         return (
-          <div className="w-full h-32 mb-8">
+          <div className="w-full h-32 mb-8" key={id}>
             <label htmlFor={id}>
               <div className="flex justify-between">
                 <input
@@ -34,10 +35,10 @@ const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions, setIsChanged }) =
                   value={question}
                   onChange={(e) => {
                     setIsChanged(true);
-                    setApplyQuestions([
-                      ...applyQuestions.slice(0, idx),
+                    setApplyQuestions((prev) => [
+                      ...prev.slice(0, idx),
                       { id, question: e.target.value, content },
-                      ...applyQuestions.slice(idx + 1),
+                      ...prev.slice(idx + 1),
                     ]);
                   }}
                   placeholder="목록 제목을 입력해주세요"
@@ -60,10 +61,10 @@ const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions, setIsChanged }) =
                 className="w-full p-1 border-2 resize-none h-2/3 border-borderColor focus:outline-none focus:border-grayDark text-grayDark"
                 onChange={(e) => {
                   setIsChanged(true);
-                  setApplyQuestions([
-                    ...applyQuestions.slice(0, idx),
+                  setApplyQuestions((prev) => [
+                    ...prev.slice(0, idx),
                     { id, content: e.target.value, question },
-                    ...applyQuestions.slice(idx + 1),
+                    ...prev.slice(idx + 1),
                   ]);
                 }}
                 placeholder="목록에 대한 설명을 입력해주세요"

--- a/src/page/Recruit/RecruitFormAdmin.jsx
+++ b/src/page/Recruit/RecruitFormAdmin.jsx
@@ -31,7 +31,7 @@ const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions, setIsChanged }) =
             <label htmlFor={id}>
               <div className="flex justify-between">
                 <input
-                  className="relative w-9/12 mb-3 border-b-2 border-borderColor focus:outline-none focus:border-b-grayDark text-grayDark"
+                  className="relative w-9/12 p-1 px-3 mb-3 border-b-2 border-borderColor focus:outline-none focus:border-b-grayDark text-grayDark"
                   value={question}
                   onChange={(e) => {
                     setIsChanged(true);
@@ -45,7 +45,7 @@ const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions, setIsChanged }) =
                 />
                 <div className="flex justify-end w-1/6 h-full">
                   <button
-                    className="w-full font-bold border-2 rounded border-error text-error"
+                    className="w-full font-bold border rounded border-error text-error"
                     type="button"
                     onClick={() => removeQuestion(idx)}
                   >
@@ -58,7 +58,7 @@ const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions, setIsChanged }) =
                 name={id}
                 id={id}
                 value={content}
-                className="w-full p-1 border-2 resize-none h-2/3 border-borderColor focus:outline-none focus:border-grayDark text-grayDark"
+                className="w-full p-3 border resize-none h-2/3 border-borderColor focus:outline-none focus:border-grayDark text-grayDark"
                 onChange={(e) => {
                   setIsChanged(true);
                   setApplyQuestions((prev) => [
@@ -78,7 +78,7 @@ const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions, setIsChanged }) =
         className="flex items-center justify-start w-1/3 text-placeHolder hover:underline"
         onClick={addQuestion}
       >
-        <CiSquarePlus size={32} className="mr-2 text-grayDark" />
+        <CiSquarePlus size={32} className="mr-2 text-placeHolder" />
         <p className="h-full hover:underline">지원서 목록 추가</p>
       </button>
     </>

--- a/src/page/Recruit/RecruitFormAdmin.jsx
+++ b/src/page/Recruit/RecruitFormAdmin.jsx
@@ -3,8 +3,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CiSquarePlus } from 'react-icons/ci';
 
-const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions }) => {
+const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions, setIsChanged }) => {
   const addQuestion = () => {
+    setIsChanged(true);
     setApplyQuestions([
       ...applyQuestions,
       {
@@ -16,6 +17,7 @@ const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions }) => {
   };
 
   const removeQuestion = (index) => {
+    setIsChanged(true);
     setApplyQuestions(applyQuestions.filter((applyQuestion, idx) => idx !== index));
   };
 
@@ -28,9 +30,10 @@ const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions }) => {
             <label htmlFor={id}>
               <div className="flex justify-between">
                 <input
-                  className="relative w-9/12 mb-3 border-b-2 border-borderColor focus:outline-none focus:border-b-grayDark"
+                  className="relative w-9/12 mb-3 border-b-2 border-borderColor focus:outline-none focus:border-b-grayDark text-grayDark"
                   value={question}
                   onChange={(e) => {
+                    setIsChanged(true);
                     setApplyQuestions([
                       ...applyQuestions.slice(0, idx),
                       { id, question: e.target.value, content },
@@ -54,8 +57,9 @@ const RecruitFormAdmin = ({ applyQuestions, setApplyQuestions }) => {
                 name={id}
                 id={id}
                 value={content}
-                className="w-full p-1 border-2 resize-none h-2/3 border-borderColor focus:outline-none focus:border-grayDark"
+                className="w-full p-1 border-2 resize-none h-2/3 border-borderColor focus:outline-none focus:border-grayDark text-grayDark"
                 onChange={(e) => {
+                  setIsChanged(true);
                   setApplyQuestions([
                     ...applyQuestions.slice(0, idx),
                     { id, content: e.target.value, question },
@@ -89,6 +93,7 @@ RecruitFormAdmin.propTypes = {
     }),
   ).isRequired,
   setApplyQuestions: PropTypes.func.isRequired,
+  setIsChanged: PropTypes.func.isRequired,
 };
 
 export default RecruitFormAdmin;

--- a/src/page/Recruit/RecruitFormUser.jsx
+++ b/src/page/Recruit/RecruitFormUser.jsx
@@ -10,13 +10,13 @@ const RecruitFormUser = ({ applyQuestions }) => {
         return (
           <div className="w-full h-32 mb-8">
             <label htmlFor={id}>
-              <p className="relative mb-3">{question}</p>
+              <p className="relative mb-3 text-grayDark">{question}</p>
               <textarea
                 type="text"
                 name={id}
                 id={id}
                 placeholder={content}
-                className="w-full p-1 border-2 resize-none h-2/3 border-borderColor focus:outline-none focus:border-grayDark"
+                className="w-full p-1 border-2 resize-none h-2/3 border-borderColor focus:outline-none focus:border-grayDark text-grayDark"
               />
             </label>
           </div>

--- a/src/page/Recruit/RecruitFormUser.jsx
+++ b/src/page/Recruit/RecruitFormUser.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+
+const RecruitFormUser = ({ applyQuestions }) => {
+  return (
+    <>
+      {applyQuestions.map((applyQuestion) => {
+        const { id, question, content } = applyQuestion;
+        return (
+          <div className="w-full h-32 mb-8">
+            <label htmlFor={id}>
+              <p className="relative mb-3">{question}</p>
+              <textarea
+                type="text"
+                name={id}
+                id={id}
+                placeholder={content}
+                className="w-full p-1 border-2 resize-none h-2/3 border-borderColor focus:outline-none focus:border-grayDark"
+              />
+            </label>
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
+RecruitFormUser.propTypes = {
+  applyQuestions: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      question: PropTypes.string,
+      content: PropTypes.string,
+    }),
+  ).isRequired,
+};
+
+export default RecruitFormUser;

--- a/src/page/Recruit/RecruitFormUser.jsx
+++ b/src/page/Recruit/RecruitFormUser.jsx
@@ -5,10 +5,9 @@ import PropTypes from 'prop-types';
 const RecruitFormUser = ({ applyQuestions }) => {
   return (
     <>
-      {applyQuestions.map((applyQuestion) => {
-        const { id, question, content } = applyQuestion;
+      {applyQuestions.map(({ id, question, content }) => {
         return (
-          <div className="w-full h-32 mb-8">
+          <div className="w-full h-32 mb-8" key={id}>
             <label htmlFor={id}>
               <p className="relative mb-3 text-grayDark">{question}</p>
               <textarea

--- a/src/page/Recruit/RecruitFormUser.jsx
+++ b/src/page/Recruit/RecruitFormUser.jsx
@@ -15,7 +15,7 @@ const RecruitFormUser = ({ applyQuestions }) => {
                 name={id}
                 id={id}
                 placeholder={content}
-                className="w-full p-1 border-2 resize-none h-2/3 border-borderColor focus:outline-none focus:border-grayDark text-grayDark"
+                className="w-full p-3 border resize-none h-2/3 border-borderColor focus:outline-none focus:border-grayDark text-grayDark"
               />
             </label>
           </div>


### PR DESCRIPTION
## 관련이슈

- #38 

## 요약

신입 회원 모집 페이지를 관리자 권한으로 접속했을 때 보이는 페이지를 추가했습니다.

## 상세

- 관리자 화면 추가했습니다.
- 목록이 화면을 넘어갈 경우 스크롤 시 좌측 모집 설명란이 따라가도록 변경했습니다.
- 목록 추가 및 삭제 기능을 추가했습니다.
- 목록 사항이 변경되면 제출 버튼 비활성화 기능을 추가했습니다.

## 리뷰안내

- 리뷰 예상 소요 시간 : 20분
- 참고사항
  - 관리자 화면을 보기 위해서는 권한이 admin으로 설정되어야 합니다.
  - 기본 항목을 하드코딩했습니다. 추후에 api 추가와 같이 변경할 예정입니다.
  - 신입회원 모집 관련 api 논의가 필요할 것 같습니다.
- 프리뷰이미지
<img width="1280" alt="image" src="https://github.com/Untoc-Web-Develop/Untoc-Front/assets/63997481/29ed907d-d215-4b1f-83f9-d2c6a938ba5b">
<img width="1280" alt="image" src="https://github.com/Untoc-Web-Develop/Untoc-Front/assets/63997481/2971906b-b862-42cb-98db-1fbe773cc84f">

