### PR TITLE
Feature/공용 모달 #53

### DIFF
--- a/src/components/Modals/AlertModal.jsx
+++ b/src/components/Modals/AlertModal.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+
+import Modal from './Modal';
+
+const AlertModal = ({ children, isOpen, setIsOpen, outsideClose, closeText }) => {
+  return (
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen} outsideClose={outsideClose}>
+      <div className="h-full w-full flex flex-col justify-center items-center">
+        <div className="h-3/4 w-full text-grayDark font-bold text-md flex justify-center items-center">{children}</div>
+        <div className="h-1/4 w-full flex justify-center items-center">
+          <button
+            className="h-1/2 w-1/5 rounded-lg border border-yellowPoint text-yellowPoint font-bold text-md"
+            type="button"
+            onClick={() => setIsOpen(false)}
+          >
+            {closeText}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+AlertModal.propTypes = {
+  children: PropTypes.node.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  setIsOpen: PropTypes.func.isRequired,
+  outsideClose: PropTypes.bool,
+  closeText: PropTypes.string,
+};
+
+AlertModal.defaultProps = {
+  outsideClose: false,
+  closeText: '확인',
+};
+
+export default AlertModal;

--- a/src/components/Modals/AlertModal.jsx
+++ b/src/components/Modals/AlertModal.jsx
@@ -4,18 +4,23 @@ import PropTypes from 'prop-types';
 
 import Modal from './Modal';
 
-const AlertModal = ({ children, isOpen, setIsOpen, outsideClose, closeText }) => {
+const AlertModal = ({ children, isOpen, setIsOpen, onClose, outsideClose, closeBtnText }) => {
+  const handleClose = () => {
+    onClose();
+    setIsOpen(false);
+  };
+
   return (
-    <Modal isOpen={isOpen} setIsOpen={setIsOpen} outsideClose={outsideClose}>
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen} onClose={onClose} outsideClose={outsideClose}>
       <div className="h-full w-full flex flex-col justify-center items-center">
         <div className="h-3/4 w-full text-grayDark font-bold text-md flex justify-center items-center">{children}</div>
         <div className="h-1/4 w-full flex justify-center items-center">
           <button
             className="h-1/2 w-1/5 rounded-lg border border-yellowPoint text-yellowPoint font-bold text-md"
             type="button"
-            onClick={() => setIsOpen(false)}
+            onClick={handleClose}
           >
-            {closeText}
+            {closeBtnText}
           </button>
         </div>
       </div>
@@ -27,13 +32,15 @@ AlertModal.propTypes = {
   children: PropTypes.node.isRequired,
   isOpen: PropTypes.bool.isRequired,
   setIsOpen: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
   outsideClose: PropTypes.bool,
-  closeText: PropTypes.string,
+  closeBtnText: PropTypes.string,
 };
 
 AlertModal.defaultProps = {
   outsideClose: false,
-  closeText: '확인',
+  onClose: () => {},
+  closeBtnText: '확인',
 };
 
 export default AlertModal;

--- a/src/components/Modals/ConfirmModal.jsx
+++ b/src/components/Modals/ConfirmModal.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+
+import Modal from './Modal';
+
+const ConfirmModal = ({ children, isOpen, setIsOpen, outsideClose, closeText, confirmText, confirmEvent }) => {
+  return (
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen} outsideClose={outsideClose}>
+      <div className="h-full w-full flex flex-col justify-center items-end">
+        <div className="h-3/4 w-full text-grayDark font-bold text-md flex justify-center items-center">{children}</div>
+        <div className="h-1/4 w-3/5 flex justify-center items-start">
+          <button
+            className="h-1/2 w-1/3 rounded-lg border border-borderColor text-grayDark font-bold text-md mr-3"
+            type="button"
+            onClick={() => setIsOpen(false)}
+          >
+            {closeText}
+          </button>
+          <button
+            className="h-1/2 w-1/3 rounded-lg border border-yellowPoint text-yellowPoint font-bold text-md"
+            type="button"
+            onClick={() => {
+              setIsOpen(false);
+              confirmEvent();
+            }}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+ConfirmModal.propTypes = {
+  children: PropTypes.node.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  setIsOpen: PropTypes.func.isRequired,
+  outsideClose: PropTypes.bool,
+  closeText: PropTypes.string,
+  confirmText: PropTypes.string,
+  confirmEvent: PropTypes.func,
+};
+
+ConfirmModal.defaultProps = {
+  outsideClose: false,
+  closeText: '취소',
+  confirmText: '확인',
+  confirmEvent: () => {},
+};
+
+export default ConfirmModal;

--- a/src/components/Modals/ConfirmModal.jsx
+++ b/src/components/Modals/ConfirmModal.jsx
@@ -4,28 +4,44 @@ import PropTypes from 'prop-types';
 
 import Modal from './Modal';
 
-const ConfirmModal = ({ children, isOpen, setIsOpen, outsideClose, closeText, confirmText, confirmEvent }) => {
+const ConfirmModal = ({
+  children,
+  isOpen,
+  setIsOpen,
+  onClose,
+  outsideClose,
+  closeBtnText,
+  confirmBtnText,
+  onConfirm,
+}) => {
+  const handleClose = () => {
+    onClose();
+    setIsOpen(false);
+  };
+
+  const handleConfirm = () => {
+    onConfirm();
+    setIsOpen(false);
+  };
+
   return (
-    <Modal isOpen={isOpen} setIsOpen={setIsOpen} outsideClose={outsideClose}>
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen} outsideClose={outsideClose} onClose={onClose}>
       <div className="h-full w-full flex flex-col justify-center items-end">
         <div className="h-3/4 w-full text-grayDark font-bold text-md flex justify-center items-center">{children}</div>
         <div className="h-1/4 w-3/5 flex justify-center items-start">
           <button
             className="h-1/2 w-1/3 rounded-lg border border-borderColor text-grayDark font-bold text-md mr-3"
             type="button"
-            onClick={() => setIsOpen(false)}
+            onClick={handleClose}
           >
-            {closeText}
+            {closeBtnText}
           </button>
           <button
             className="h-1/2 w-1/3 rounded-lg border border-yellowPoint text-yellowPoint font-bold text-md"
             type="button"
-            onClick={() => {
-              setIsOpen(false);
-              confirmEvent();
-            }}
+            onClick={handleConfirm}
           >
-            {confirmText}
+            {confirmBtnText}
           </button>
         </div>
       </div>
@@ -37,17 +53,19 @@ ConfirmModal.propTypes = {
   children: PropTypes.node.isRequired,
   isOpen: PropTypes.bool.isRequired,
   setIsOpen: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
   outsideClose: PropTypes.bool,
-  closeText: PropTypes.string,
-  confirmText: PropTypes.string,
-  confirmEvent: PropTypes.func,
+  closeBtnText: PropTypes.string,
+  confirmBtnText: PropTypes.string,
+  onConfirm: PropTypes.func,
 };
 
 ConfirmModal.defaultProps = {
+  onClose: () => {},
   outsideClose: false,
-  closeText: '취소',
-  confirmText: '확인',
-  confirmEvent: () => {},
+  closeBtnText: '취소',
+  confirmBtnText: '확인',
+  onConfirm: () => {},
 };
 
 export default ConfirmModal;

--- a/src/components/Modals/Modal.jsx
+++ b/src/components/Modals/Modal.jsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useRef } from 'react';
+
+import PropTypes from 'prop-types';
+
+const Modal = ({ children, isOpen, setIsOpen }) => {
+  const modalRef = useRef();
+
+  useEffect(() => {
+    const handleOutsideClick = (event) => {
+      if (modalRef.current && !modalRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleOutsideClick);
+
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [modalRef, setIsOpen]);
+
+  if (!isOpen) return null;
+  return (
+    <div className="z-[999] h-screen w-screen fixed top-0 left-0 flex flex-col justify-center items-center bg-opacity-50 bg-black">
+      <div ref={modalRef} className="h-72 w-[30rem] bg-white shadow-xl">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+Modal.propTypes = {
+  children: PropTypes.node.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  setIsOpen: PropTypes.func.isRequired,
+};
+
+export default Modal;

--- a/src/components/Modals/Modal.jsx
+++ b/src/components/Modals/Modal.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 
 import PropTypes from 'prop-types';
 
-const Modal = ({ children, isOpen, setIsOpen }) => {
+const Modal = ({ children, isOpen, setIsOpen, outsideClose }) => {
   const modalRef = useRef();
 
   useEffect(() => {
@@ -12,7 +12,7 @@ const Modal = ({ children, isOpen, setIsOpen }) => {
       }
     };
 
-    document.addEventListener('mousedown', handleOutsideClick);
+    if (outsideClose) document.addEventListener('mousedown', handleOutsideClick);
 
     return () => {
       document.removeEventListener('mousedown', handleOutsideClick);
@@ -33,6 +33,11 @@ Modal.propTypes = {
   children: PropTypes.node.isRequired,
   isOpen: PropTypes.bool.isRequired,
   setIsOpen: PropTypes.func.isRequired,
+  outsideClose: PropTypes.bool,
+};
+
+Modal.defaultProps = {
+  outsideClose: false,
 };
 
 export default Modal;

--- a/src/components/Modals/Modal.jsx
+++ b/src/components/Modals/Modal.jsx
@@ -1,28 +1,21 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 
 import PropTypes from 'prop-types';
 
-const Modal = ({ children, isOpen, setIsOpen, outsideClose }) => {
-  const modalRef = useRef();
-
-  useEffect(() => {
-    const handleOutsideClick = (event) => {
-      if (modalRef.current && !modalRef.current.contains(event.target)) {
-        setIsOpen(false);
-      }
-    };
-
-    if (outsideClose) document.addEventListener('mousedown', handleOutsideClick);
-
-    return () => {
-      document.removeEventListener('mousedown', handleOutsideClick);
-    };
-  }, [modalRef, setIsOpen]);
+const Modal = ({ children, isOpen, setIsOpen, onClose, outsideClose }) => {
+  const handleClose = () => {
+    onClose();
+    setIsOpen(false);
+  };
 
   if (!isOpen) return null;
   return (
-    <div className="z-[999] h-screen w-screen fixed top-0 left-0 flex flex-col justify-center items-center bg-opacity-50 bg-black">
-      <div ref={modalRef} className="h-60 w-[28rem] bg-white shadow-xl">
+    <div
+      aria-hidden="true"
+      onClick={outsideClose ? handleClose : () => {}}
+      className="z-[999] h-screen w-screen fixed top-0 left-0 flex flex-col justify-center items-center bg-opacity-50 bg-black"
+    >
+      <div aria-hidden="true" onClick={(e) => e.stopPropagation()} className="h-60 w-[28rem] bg-white shadow-xl">
         {children}
       </div>
     </div>
@@ -33,10 +26,12 @@ Modal.propTypes = {
   children: PropTypes.node.isRequired,
   isOpen: PropTypes.bool.isRequired,
   setIsOpen: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
   outsideClose: PropTypes.bool,
 };
 
 Modal.defaultProps = {
+  onClose: () => {},
   outsideClose: false,
 };
 

--- a/src/components/Modals/Modal.jsx
+++ b/src/components/Modals/Modal.jsx
@@ -22,7 +22,7 @@ const Modal = ({ children, isOpen, setIsOpen, outsideClose }) => {
   if (!isOpen) return null;
   return (
     <div className="z-[999] h-screen w-screen fixed top-0 left-0 flex flex-col justify-center items-center bg-opacity-50 bg-black">
-      <div ref={modalRef} className="h-72 w-[30rem] bg-white shadow-xl">
+      <div ref={modalRef} className="h-60 w-[28rem] bg-white shadow-xl">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## 관련이슈

- #53 

## 요약

Modal, AlertModal, ConfirmModal 제작

## 사용 방법

1. 모달창 on/off를 위한 useState 변수 생성
2. Modal, AlertModal, ConfirmModal 중 상황에 맞는 모달 선택
3. props 부여
  - isOpen (필수) : 모달창 상태 변수
  - setIsOpen (필수) : 모달창 상태 변수 변경 함수
  - onClose : 모달창 닫기 시 실행 함수
  - onConfirm : 모달창 확인 시 실행 함수
  - closeBtnText : 닫기 버튼 텍스트
  - confirmBtnText : 확인 버튼 텍스트
  - outsideclose : 모달 영역 바깥 클릭 시 자동 닫힘 기능
<img width="317" alt="image" src="https://github.com/Untoc-Web-Develop/Untoc-Front/assets/63997481/cf209886-ffbb-4217-b678-c387250a9923">

## 상세

- AlertModal과 ConfirmModal 모두 Modal을 통해 구현
- outsideClose props를 통해 모달 바깥영역 클릭시 닫힘 기능 구현
- ConfirmModal의 confirmEvent props를 통해 실행할 함수 부여 가능

## 리뷰안내

- 리뷰 예상 소요 시간: 15분
- 프리뷰이미지

Modal
<img width="916" alt="스크린샷 2023-12-06 161815" src="https://github.com/Untoc-Web-Develop/Untoc-Front/assets/63997481/6a3fd31d-7ddc-492c-bd06-627ecd73a7ba">

AlertModal
<img width="871" alt="스크린샷 2023-12-06 161655" src="https://github.com/Untoc-Web-Develop/Untoc-Front/assets/63997481/09adf1cf-b970-44b7-8220-8c0002619a93">

ConfirmModal
<img width="873" alt="스크린샷 2023-12-06 161527" src="https://github.com/Untoc-Web-Develop/Untoc-Front/assets/63997481/34c5ed8f-b4cf-404c-8c86-dd235c0d6bd0">

