### PR TITLE
Feature/tailwindcss sort plugin #51

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
   "singleQuote": true,
   "trailingComma": "all",
   "printWidth": 120,
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,8 +32,9 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "prettier": "3.0.3",
+        "prettier": "^3.0.3",
         "prettier-eslint": "^15.0.1",
+        "prettier-plugin-tailwindcss": "^0.5.9",
         "tailwindcss": "^3.3.3"
       }
     },
@@ -14784,6 +14785,75 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.9.tgz",
+      "integrity": "sha512-9x3t1s2Cjbut2QiP+O0mDqV3gLXTe2CgRlQDgucopVkUdw26sQi53p/q4qvGxMLBDfk/dcTV57Aa/zYwz9l8Ew==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "prettier-plugin-twig-melody": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -28836,6 +28906,13 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.9.tgz",
+      "integrity": "sha512-9x3t1s2Cjbut2QiP+O0mDqV3gLXTe2CgRlQDgucopVkUdw26sQi53p/q4qvGxMLBDfk/dcTV57Aa/zYwz9l8Ew==",
+      "dev": true,
+      "requires": {}
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,9 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "prettier": "3.0.3",
+    "prettier": "^3.0.3",
     "prettier-eslint": "^15.0.1",
+    "prettier-plugin-tailwindcss": "^0.5.9",
     "tailwindcss": "^3.3.3"
   }
 }

--- a/src/components/Layouts/Header/Header.jsx
+++ b/src/components/Layouts/Header/Header.jsx
@@ -13,13 +13,13 @@ const Header = () => {
   const { isLogin, OnlyLogin } = useRoleCheck();
 
   return (
-    <div className="flex place-items-center w-screen h-10 bg-white shadow-lg px-40 py-2">
+    <div className="flex h-10 w-screen place-items-center bg-white px-40 py-2 shadow-lg">
       <Link to="/">
         <Logo />
       </Link>
-      <div className="border-l h-full border-gray-400 mx-8" />
+      <div className="mx-8 h-full border-l border-gray-400" />
       <HeaderTab />
-      <div className="ml-auto grid grid-flow-col gap-x-5 place-items-center">
+      <div className="ml-auto grid grid-flow-col place-items-center gap-x-5">
         <OnlyLogin>
           <button type="button">
             <Search className="text-lg" />

--- a/src/components/Layouts/MainLayout.jsx
+++ b/src/components/Layouts/MainLayout.jsx
@@ -5,7 +5,7 @@ import Header from './Header/Header';
 
 const MainLayout = () => {
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex min-h-screen flex-col">
       <Header />
       <div>
         <Outlet />

--- a/src/components/Tab/StandardTab.jsx
+++ b/src/components/Tab/StandardTab.jsx
@@ -40,7 +40,7 @@ const StandardTab = ({ tabs, onSelected, size, activeTab, setActiveTab }) => {
           >
             <p
               className={`${textSize} font-bold ${
-                index === activeTab ? ' text-yellowPoint border-yellowPoint border-b-2' : ' text-placeHolder'
+                index === activeTab ? ' border-b-2 border-yellowPoint text-yellowPoint' : ' text-placeHolder'
               }`}
             >
               {tab.title}


### PR DESCRIPTION
## 관련이슈

- #51 

## 요약

tailwindcss 정렬을 위한 prettier 플러그인 설치 및 적용

## 상세

- [tailwindcss 공식 블로그 참고](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier)

## 리뷰안내

- 2분
- 일단 제가 작업했고 현제 추가작업이 없는 컴포넌트에 적용해봤습니다. 파일열고 autosave로 적용 가능하니 자기가 작업했고 현제 작업 없는 파일들 중간중간에 적용 부탁드립니다.
